### PR TITLE
Fix issues with curl requests.

### DIFF
--- a/Routes/post/postmathima.php
+++ b/Routes/post/postmathima.php
@@ -127,6 +127,7 @@ $app->post('/mathima', function($request, $response) use ($diy_storage, $diy_res
 					$contentellakm='';
 					$contentellakt='';
 					$contentellaku='';
+					$output='';
 					$stmt1->execute();
 					$ii = $ii + 2;
 				}

--- a/Routes/post/postmathima.php
+++ b/Routes/post/postmathima.php
@@ -114,13 +114,13 @@ $app->post('/mathima', function($request, $response) use ($diy_storage, $diy_res
 					$TITLOS = $dget["email"];
 
 					$data_json =  '{ "title": "'.$TITLOS.'", "status":"pending" }';
-					$exec = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X post  '.$restapipoint.' -d '."'".$data_json."'";
+					$exec = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X POST  '.$restapipoint.' -d '."'".$data_json."'";
 
 					$exec .= " | jq '.id' 2>&1";
 					exec($exec, $output, $return_var);
 					$fields1['fields']=$fields;
 					$content1 = json_encode($fields1);
-					$exec1 = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X post  '.$restapipoint2.'/${'.$output[0].'} -d '."'".$content1."'";
+					$exec1 = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X POST  '.$restapipoint2.'/${'.$output[0].'} -d '."'".$content1."'";
 
 					$exec1 .= " 2>&1";
 					exec($exec1, $output1, $return_var1);

--- a/Routes/post/postmathima.php
+++ b/Routes/post/postmathima.php
@@ -120,7 +120,7 @@ $app->post('/mathima', function($request, $response) use ($diy_storage, $diy_res
 					exec($exec, $output, $return_var);
 					$fields1['fields']=$fields;
 					$content1 = json_encode($fields1);
-					$exec1 = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X POST  '.$restapipoint2.'/${'.$output[0].'} -d '."'".$content1."'";
+					$exec1 = 'curl -k --header "Authorization: Basic '.$restapitmp.'" -H "Content-Type: application/json" -X POST  '.$restapipoint2.'/'.$output[0].' -d '."'".$content1."'";
 
 					$exec1 .= " 2>&1";
 					exec($exec1, $output1, $return_var1);


### PR DESCRIPTION
Fixes some issues regarding the curl requests to the WordPress and ACF API. With this fix the POST requests work as expected ,the first creates the wordpress post and then the second modifies the advanced_custom_fields post fields. The loop over the POST requests also works, the above 2 requests should be sent for each course+software, so more that one software/course can be added to the questionnaire.